### PR TITLE
Fixing Issue #7 - Updating docker file to latest release of Rocket.Chat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.baloise</groupId>
 	<artifactId>rocket-chat-rest-client</artifactId>
-	<version>0.1.1-SNAPSHOT</version>
+	<version>0.1.2-SNAPSHOT</version>
 	<properties>
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
@@ -49,9 +49,9 @@
 						<configuration>
 							<images>
 								<image>
-									<name>rocketchat</name>
+									<name>rocketchat/it</name>
 									<build>
-										<dockerFileDir>${project.basedir}/docker/rocketchat</dockerFileDir>
+										<dockerFileDir>rocketchat</dockerFileDir>
 									</build>
 									<run>
 										<links>

--- a/src/main/docker/rocketchat/Dockerfile
+++ b/src/main/docker/rocketchat/Dockerfile
@@ -1,6 +1,6 @@
 FROM rocketchat/base:4
 
-ENV RC_VERSION develop
+ENV RC_VERSION latest
 
 MAINTAINER buildmaster@rocket.chat
 


### PR DESCRIPTION
Fix to issue #7 

updated the dockerfile to pull latest image
incremented pom for bugfix release
moved dockerfile to default fabric8:docker-maven-plugin location