### PR TITLE
Add settings#list, disable API rate limit, do not trim traces on failed unit test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,9 @@
 										<dependsOn>
 											<container>mongo</container>
 										</dependsOn>
+										<env>
+											<API_Enable_Rate_Limiter>false</API_Enable_Rate_Limiter>
+										</env>
 										<wait>
 											<http>
 												<url>http://localhost:23737</url>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,8 @@
 											<arg>mongo</arg>
 											<arg>mongo/rocketchat</arg>
 											<arg>--eval</arg>
-											<arg>rs.initiate({ _id:'rs0', members: [ { _id: 0, host: 'localhost:27017' }]})</arg>
+											<arg>rs.initiate({ _id:'rs0', members: [ { _id: 0, host:
+												'localhost:27017' }]})</arg>
 										</cmd>
 										<network>
 											<name>backend</name>
@@ -161,7 +162,9 @@
 						</goals>
 					</execution>
 				</executions>
-				<configuration />
+				<configuration>
+					<trimStackTrace>false</trimStackTrace>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/github/baloise/rocketchatrestclient/RocketChatClientCallBuilder.java
+++ b/src/main/java/com/github/baloise/rocketchatrestclient/RocketChatClientCallBuilder.java
@@ -101,9 +101,11 @@ public class RocketChatClientCallBuilder {
         if (loginResult.getStatus() == 401)
             throw new IOException("The username and password provided are incorrect.");
 
-        if (loginResult.getStatus() != 200)
-            throw new IOException("The login failed with a result of: " + loginResult.getStatus());
-
+        
+		if (loginResult.getStatus() != 200)
+			throw new IOException("The login failed with a result of: " + loginResult.getStatus()
+				+ " (" + loginResult.getStatusText() + ")");
+		
         JSONObject data = loginResult.getBody().getObject().getJSONObject("data");
         this.authToken = data.getString("authToken");
         this.userId = data.getString("userId");

--- a/src/main/java/com/github/baloise/rocketchatrestclient/RocketChatRestApiV1Settings.java
+++ b/src/main/java/com/github/baloise/rocketchatrestclient/RocketChatRestApiV1Settings.java
@@ -11,6 +11,18 @@ public class RocketChatRestApiV1Settings {
 	protected RocketChatRestApiV1Settings(RocketChatClientCallBuilder callBuilder) {
 		this.callBuilder = callBuilder;
 	}
+	
+	public Setting[] list() throws IOException{
+		RocketChatQueryParams rocketChatQueryParams = new RocketChatQueryParams("count", "0");
+		RocketChatClientResponse res =
+			this.callBuilder.buildCall(RocketChatRestApiV1.SettingsGetAll, rocketChatQueryParams);
+		
+		if (!res.isSuccessful())
+			throw new IOException(
+				"The call to get Settings was unsuccessful: \"" + res.getError() + "\"");
+		
+		return res.getSettings();
+	}
 
 	public Setting getById(String settingId) throws IOException {
 		RocketChatQueryParams rocketChatQueryParams = new RocketChatQueryParams(

--- a/src/main/java/com/github/baloise/rocketchatrestclient/model/Setting.java
+++ b/src/main/java/com/github/baloise/rocketchatrestclient/model/Setting.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 
 public class Setting {
 	private String id;
-	private String value;
+	private Object value;
 
 	@JsonGetter("_id")
 	public String getId() {
@@ -18,12 +18,12 @@ public class Setting {
 	}
 
 	@JsonGetter("value")
-	public String getValue() {
+	public Object getValue() {
 		return value;
 	}
 
 	@JsonSetter("value")
-	public void setValue(String value) {
+	public void setValue(Object value) {
 		this.value = value;
 	}
 

--- a/src/test/java/com/github/baloise/rocketchatrestclient/RocketChatClientTestIT.java
+++ b/src/test/java/com/github/baloise/rocketchatrestclient/RocketChatClientTestIT.java
@@ -10,6 +10,7 @@ import com.github.baloise.rocketchatrestclient.model.Channel;
 import com.github.baloise.rocketchatrestclient.model.Group;
 import com.github.baloise.rocketchatrestclient.model.Room;
 import com.github.baloise.rocketchatrestclient.model.ServerInfo;
+import com.github.baloise.rocketchatrestclient.model.Setting;
 import com.github.baloise.rocketchatrestclient.model.User;
 import com.github.baloise.rocketchatrestclient.util.TestConnectionInfo;
 
@@ -148,4 +149,19 @@ public class RocketChatClientTestIT {
         group = this.rc.getGroupsApi().rename(group);
         assertEquals(TEST_CASE_8, group.getName());
     }
+    
+	@Test
+	public void testGetSettingById() throws Exception{
+		Setting setting = this.rc.getSettingsApi().getById("Organization_Name");
+		assertEquals("Organization_Name", setting.getId());
+		assertEquals("", setting.getValue());
+	}
+	
+	@Test
+	public void testSetSettingById() throws Exception{
+		this.rc.getSettingsApi().setById("Organization_Name", "TestOrganizationName");
+		Setting setting = this.rc.getSettingsApi().getById("Organization_Name");
+		assertEquals("TestOrganizationName", setting.getValue());
+	}
+	
 }

--- a/src/test/java/com/github/baloise/rocketchatrestclient/RocketChatClientTestIT.java
+++ b/src/test/java/com/github/baloise/rocketchatrestclient/RocketChatClientTestIT.java
@@ -2,6 +2,9 @@ package com.github.baloise.rocketchatrestclient;
 
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -164,4 +167,13 @@ public class RocketChatClientTestIT {
 		assertEquals("TestOrganizationName", setting.getValue());
 	}
 	
+	@Test
+	public void testListSettings() throws Exception{
+		Setting[] settings = this.rc.getSettingsApi().list();
+		assertNotNull(settings);
+		List<Setting> _settings = Arrays.asList(settings);
+		Setting organizationNameSetting = _settings.stream()
+			.filter(e -> "Organization_Name".equals(e.getId())).findFirst().orElse(null);
+		assertNotNull(organizationNameSetting);
+	}
 }


### PR DESCRIPTION
This patch does 

* provide Settings#list to show all setting values
* disable the api rate limitation, in order for the test not to fail with
* code 429 - where the status code output is extended to include the statusText