### PR TITLE
Downgrade integration tests to version 3.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
 
-	<dependencies>
+	<dependencies> 
 		<dependency>
 			<groupId>com.mashape.unirest</groupId>
 			<artifactId>unirest-java</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 							<autoCreateCustomNetworks>true</autoCreateCustomNetworks>
 							<images>
 								<image>
-									<name>rocketchat:3.8.3</name>
+									<name>rocketchat:3.3.3</name>
 									<alias>rocketchat</alias>
 									<build>
 										<dockerFileDir>rocketchat</dockerFileDir>

--- a/src/main/docker/rocketchat/Dockerfile
+++ b/src/main/docker/rocketchat/Dockerfile
@@ -1,6 +1,6 @@
 FROM rocketchat/base:12.16
 
-ENV RC_VERSION latest
+ENV RC_VERSION 3.3.3
 
 MAINTAINER buildmaster@rocket.chat
 


### PR DESCRIPTION
The integration tests no longer work with rocket chat "latest" (3.14.x).

Fixes #63 
